### PR TITLE
Refactor Supabase configuration to use environment variables and streamline input tracking logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,19 +10,28 @@
   <script
   src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"
   type="text/javascript"></script>
+<!-- Configuration -->
+<script src="js/config.js" type="text/javascript"></script>
 <!-- Supabase JavaScript Client -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <!-- Supabase Configuration -->
 <script>
 // Initialize Supabase client globally
-const SUPABASE_CONFIG = {
-    url: window.env.SUPABASE_URL,
-    anonKey: window.env.SUPABASE_ANON_KEY
-};
+let SUPABASE_CONFIG = null;
+
+if (typeof window.env !== 'undefined') {
+    SUPABASE_CONFIG = {
+        url: window.env.SUPABASE_URL,
+        anonKey: window.env.SUPABASE_ANON_KEY
+    };
+    console.log('✅ Environment variables loaded');
+} else {
+    console.error('Environment variables not loaded');
+}
 
 // Wait for Supabase library to load, then initialize
 function initializeSupabase() {
-    if (typeof window.supabase !== 'undefined') {
+    if (typeof window.supabase !== 'undefined' && SUPABASE_CONFIG) {
         window.supabase = window.supabase.createClient(SUPABASE_CONFIG.url, SUPABASE_CONFIG.anonKey);
         console.log('✅ Supabase client initialized successfully');
         return true;

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,7 @@
+// Environment configuration for client-side use
+// This file contains the Supabase configuration extracted from .env file
+
+window.env = {
+    SUPABASE_URL: 'https://pbgubbwkvzgfifvdjdvt.supabase.co',
+    SUPABASE_ANON_KEY: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBiZ3ViYndrdnpnZmlmdmRqZHZ0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYzNzQxNDEsImV4cCI6MjA3MTk1MDE0MX0.mSTHMDvIyJCavDwl5ygBzGzno28be5MlUbyUtvOQCdM'
+};

--- a/js/database.js
+++ b/js/database.js
@@ -168,8 +168,8 @@ async function trackInput(qprefix, inputName, inputValue, inputType, isFinalAnsw
             return await trackConsolidatedInput(attempt, inputName, inputValue, inputType, validationResult);
         }
         
-        // For regular input tracking, continue as before but limit frequency
-        return await trackRegularInput(attempt, inputName, inputValue, inputType, validationResult);
+        // Skip regular input tracking - only track final answers
+        return null;
 
     } catch (error) {
         console.error('Input tracking failed:', error);


### PR DESCRIPTION
This pull request refactors the way Supabase environment configuration is loaded and significantly simplifies the input tracking logic for question attempts. The main changes include moving environment variables to a separate config file, updating the Supabase client initialization, and restricting input tracking to only final answer submissions, improving both maintainability and data quality.

**Environment Configuration Improvements**
* Added a new `js/config.js` file to store Supabase environment variables, which are now loaded into `window.env` and referenced in `index.html` for client initialization. This decouples sensitive config from the main HTML and allows easier updates. [[1]](diffhunk://#diff-e6b9bf23c200857cae335d73c9c69a339fd6f910406858ab8ca0524e4a7a9553R1-R7) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R13-R34)

**Supabase Client Initialization**
* Updated the Supabase client setup in `index.html` to check for the presence of environment variables before initializing, with improved logging for success and error states.

**Input Tracking Logic Changes**
* Removed regular input tracking throughout the user interaction flow in `js/stackapicalls.js` and `js/database.js`; now, only final answer submissions are tracked, reducing unnecessary database writes and focusing on relevant data. [[1]](diffhunk://#diff-0ae18f8823d993e74177d2438bda05025363390e9d332c25fff2249074e5d2c3L144-R144) [[2]](diffhunk://#diff-dbdf3816d19789dd6227367bbe8935b69581a6bb9600f767ff375b3498965877L171-R172)
* Refactored the final answer submission logic to create and update question attempts only when the user submits, consolidating answers and validation results for database tracking. [[1]](diffhunk://#diff-0ae18f8823d993e74177d2438bda05025363390e9d332c25fff2249074e5d2c3L293-R302) [[2]](diffhunk://#diff-0ae18f8823d993e74177d2438bda05025363390e9d332c25fff2249074e5d2c3L360-L375)
* Simplified seed initialization in question loading to use `null` instead of `""` for clarity.